### PR TITLE
Proposal: Use Lodash for common utility functions

### DIFF
--- a/lib/common/exists-by-dot.js
+++ b/lib/common/exists-by-dot.js
@@ -1,17 +1,5 @@
+const has = require('lodash/has');
 
 module.exports = function (obj, path) {
-  const parts = path.split('.');
-  const nonLeafLen = parts.length - 1;
-
-  for (let i = 0; i < nonLeafLen; i++) {
-    let part = parts[i];
-
-    if (!(part in obj)) { return false; }
-
-    obj = obj[part];
-
-    if (typeof obj !== 'object' || obj === null) { return false; }
-  }
-
-  return parts[nonLeafLen] in obj;
+  return has(obj, path);
 };

--- a/lib/common/get-by-dot.js
+++ b/lib/common/get-by-dot.js
@@ -1,13 +1,5 @@
+const get = require('lodash/get');
 
 module.exports = function (obj, path) {
-  if (typeof obj !== 'object' || obj === null) return undefined;
-
-  if (path.indexOf('.') === -1) {
-    return obj[path];
-  }
-
-  return path.split('.').reduce(
-    (obj1, part) => (typeof obj1 === 'object' && obj1 !== null ? obj1[part] : undefined),
-    obj
-  );
+  return get(obj, path);
 };

--- a/lib/common/set-by-dot.js
+++ b/lib/common/set-by-dot.js
@@ -1,36 +1,5 @@
+const set = require('lodash/set');
 
-module.exports = function (obj, path, value, ifDelete) {
-  if (ifDelete) {
-    console.log('DEPRECATED. Use deleteByDot instead of setByDot(obj,path,value,true). (setByDot)');
-  }
-
-  if (path.indexOf('.') === -1) {
-    obj[path] = value;
-
-    if (value === undefined && ifDelete) {
-      delete obj[path];
-    }
-
-    return;
-  }
-
-  const parts = path.split('.');
-  const lastIndex = parts.length - 1;
-  return parts.reduce(
-    (obj1, part, i) => {
-      if (i !== lastIndex) {
-        if (!obj1.hasOwnProperty(part) || typeof obj1[part] !== 'object') {
-          obj1[part] = {};
-        }
-        return obj1[part];
-      }
-
-      obj1[part] = value;
-      if (value === undefined && ifDelete) {
-        delete obj1[part];
-      }
-      return obj1;
-    },
-    obj
-  );
+module.exports = function (obj, path, value) {
+  return set(obj, path, value);
 };

--- a/lib/services/dialable-phone-number.js
+++ b/lib/services/dialable-phone-number.js
@@ -4,7 +4,6 @@ const alterItems = require('./alter-items');
 module.exports = function dialablePhoneNumber (libphonenumberJs,
   defaultCountry = 'US', phoneField = 'phone', dialableField = 'dialablePhone', countryField = 'country'
 ) {
-
   return context => alterItems(rec => {
     const phone = rec[phoneField];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -480,7 +480,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -547,7 +547,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -836,7 +836,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -874,7 +874,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -1135,7 +1135,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -1544,7 +1544,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -1694,7 +1694,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -2054,7 +2054,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -2148,7 +2148,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -2491,7 +2491,7 @@
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
@@ -2642,7 +2642,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -2679,10 +2679,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -2795,7 +2794,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -2865,7 +2864,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2874,7 +2873,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -3091,7 +3090,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -3164,7 +3163,7 @@
     },
     "passport-jwt": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
       "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
       "dev": true,
       "requires": {
@@ -3198,7 +3197,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -3243,7 +3242,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -3633,7 +3632,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -4542,7 +4541,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -4575,7 +4574,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ajv": "^5.5.2",
     "debug": "^3.1.0",
     "libphonenumber-js": "^1.6.8",
+    "lodash": "^4.17.11",
     "process": "0.11.10",
     "traverse": "^0.6.6"
   },

--- a/tests/services/get-set-by-dot.test.js
+++ b/tests/services/get-set-by-dot.test.js
@@ -102,12 +102,5 @@ describe('services byDot', () => {
       setByDot(obj, 'name', { firstest: 'Donald', lastest: 'Duck' });
       assert.deepEqual(obj, { name: { firstest: 'Donald', lastest: 'Duck' } });
     });
-
-    it('deletes undefined values', () => {
-      setByDot(obj, 'name.first', undefined, true);
-      assert.deepEqual(obj, { name: { last: 'Doe' } });
-      setByDot(obj, 'name', undefined, true);
-      assert.deepEqual(obj, {});
-    });
   });
 });


### PR DESCRIPTION
[Lodash](https://lodash.com/) contains a lot of the utility functions that are implemented again as common hooks utilities. I am proposing to use the Lodash methods instead for the following reasons:

- Lodash is probably one of the most battle tested and micro-optimized npm modules and covers many edge cases we may only run into with weird bugs
- When I tried to use the existing methods (`get-by-dot` instead of `_.get`) they behaved slightly different than what I was expecting (e.g. it is not possible to escape `.` and objects with dot string names have to be handled as a special case - `_.get` does all of that already)
- Lodashs `_.get` and `_.set` are faster since it has a mechanism for caching object paths
- Less code (and typings) to maintain

All tests for the proposed changes here are still passing (except for the deprecated deleting undefined values for `set-by-dot`).