### PR TITLE
Ensure `existsByDot` and `getByDot` honour properties with dots in keys

### DIFF
--- a/lib/common/exists-by-dot.js
+++ b/lib/common/exists-by-dot.js
@@ -1,5 +1,7 @@
 
 module.exports = function (obj, path) {
+  if (path in obj) return true;
+
   const parts = path.split('.');
   const nonLeafLen = parts.length - 1;
 

--- a/lib/common/get-by-dot.js
+++ b/lib/common/get-by-dot.js
@@ -2,7 +2,7 @@
 module.exports = function (obj, path) {
   if (typeof obj !== 'object' || obj === null) return undefined;
 
-  if (path.indexOf('.') === -1) {
+  if (path.indexOf('.') === -1 || path in obj) {
     return obj[path];
   }
 

--- a/tests/services/exists-by-dot.test.js
+++ b/tests/services/exists-by-dot.test.js
@@ -42,6 +42,15 @@ describe('test existsByDot', () => {
     assert.equal(existsByDot({}, 'name'), false);
   });
 
+  it('finds property with dot in key', () => {
+    const obj = { 'name.first': 'John' };
+    assert.equal(existsByDot(obj, 'name.first'), true);
+    assert.equal(existsByDot(obj, 'name'), false);
+    assert.equal(existsByDot(obj, 'first'), false);
+    assert.equal(existsByDot(obj, 'namefirst'), false);
+    assert.equal(existsByDot(obj, 'name.first.foo'), false);
+  });
+
   it('does not throw if path ends prematurely', () => {
     assert.deepEqual(existsByDot(obj, 'x'), false);
     assert.deepEqual(existsByDot(obj, 'name.a.c.x'), false);

--- a/tests/services/get-set-by-dot.test.js
+++ b/tests/services/get-set-by-dot.test.js
@@ -22,7 +22,8 @@ describe('services byDot', () => {
             name: 'John',
             address: { line1: '100 5-th Avenue', city: 'New York' }
           }
-        }
+        },
+        'foo.bar': {}
       };
     });
 
@@ -45,6 +46,10 @@ describe('services byDot', () => {
     it('gets leaf level simple variable', () => {
       assert.equal(getByDot(obj, 'manager.employee.address.city'),
         obj.manager.employee.address.city);
+    });
+
+    it('gets top level property with dot in key', () => {
+      assert.equal(getByDot(obj, 'foo.bar'), obj['foo.bar']);
     });
 
     it('does not throw on missing path, at top', () => {


### PR DESCRIPTION
Resolves: https://github.com/feathers-plus/feathers-hooks-common/issues/514

Origin of this change is the [`keep()`](https://feathers-plus.github.io/v1/feathers-hooks-common/#keep) hook failing for object keys containing dots (like `{ 'foo.bar': true }`).
