### PR TITLE
Upgrade ajv dependency and fix failing tests.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -409,14 +409,26 @@
       "dev": true
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
       }
     },
     "align-text": {
@@ -424,6 +436,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -435,6 +448,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -950,7 +964,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.1",
@@ -1561,7 +1576,8 @@
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1628,6 +1644,18 @@
           "resolved": "https://registry.npmjs.org/@feathers-plus/batch-loader/-/batch-loader-0.3.0.tgz",
           "integrity": "sha512-buElwyOZKVI34kD7jHt+czIDv1brjXLBPJ+7is+RC98JK+TyqWIUuBJ4E0ZMjPxwwkAJIN6IATyPgvhSXhkaxw==",
           "dev": true
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
         }
       }
     },
@@ -1652,7 +1680,7 @@
       "requires": {
         "debug": "^2.2.0",
         "object.assign": "^4.0.4",
-        "sift": "github:crcn/sift.js#9cc1bbc3d4b999626aed09cbdeea4eeefce169a1"
+        "sift": "github:crcn/sift.js"
       },
       "dependencies": {
         "debug": {
@@ -1665,8 +1693,8 @@
           }
         },
         "sift": {
-          "version": "github:crcn/sift.js#9cc1bbc3d4b999626aed09cbdeea4eeefce169a1",
-          "from": "sift@github:crcn/sift.js#9cc1bbc3d4b999626aed09cbdeea4eeefce169a1",
+          "version": "github:crcn/sift.js#159fea1665c0a195034ba3175b8818ce38dca40f",
+          "from": "github:crcn/sift.js",
           "dev": true
         }
       }
@@ -2142,7 +2170,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2507,7 +2536,8 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2769,7 +2799,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -3523,7 +3554,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -4708,6 +4740,21 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
     },
     "url-pattern": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@feathersjs/errors": "^3.3.0",
     "@feathersjs/feathers": "^3.1.3",
     "@types/graphql": "^14.0.4",
-    "ajv": "^5.5.2",
+    "ajv": "^6.10.0",
     "debug": "^3.1.0",
     "graphql": "^14.0.2",
     "libphonenumber-js": "^1.6.8",

--- a/tests/services/validate-schema.test.js
+++ b/tests/services/validate-schema.test.js
@@ -12,7 +12,7 @@ const Ajv = require('ajv');
 const ajv = new Ajv({ allErrors: true });
 ajv.addFormat('startWithJo', '^Jo');
 ajv.addSchema({
-  'id': 'syncSchema',
+  '$id': 'syncSchema',
   'properties': {
     'first': { 'type': 'string', 'format': 'startWithJo' },
     'last': { 'type': 'string' }
@@ -196,7 +196,7 @@ describe('services validateSchema', () => {
       });
 
       ajvAsync.addSchema({
-        'id': 'asyncSchema',
+        '$id': 'asyncSchema',
         '$async': true,
         'properties': {
           'first': {


### PR DESCRIPTION
### Summary
Upgraded ajv dependency to newest version. Fixed failing tests. https://github.com/feathers-plus/feathers-hooks-common/issues/372


### ~~Problem~~
<details>
<summary>outdated</summary>

There's still problem with using newest Ajv and validateSchema hook in TypeScript, that I tried to fix, but couldn't figure how.

Version 6.0.0 of Ajv removed `Thenable` interface and replaced it by `PromiseLike`
[Diff](https://github.com/epoberezkin/ajv/compare/cecd4ecca66abee0441a8277c647856b09454f82...master#diff-89794cf8c2ab6af000576e99672b9b2c)


Using validate schema with instance or constructor of ajv results in one of these errors:
```
Error:(63, 28) TS2345: Argument of type '{ (options?: Options): Ajv; new (options?: Options): Ajv; ValidationError: typeof ValidationError; MissingRefError: typeof MissingRefError; $dataMetaSchema: object; }' is not assignable to parameter of type 'AjvOrNewable'.
  Type '{ (options?: Options): Ajv; new (options?: Options): Ajv; ValidationError: typeof ValidationError; MissingRefError: typeof MissingRefError; $dataMetaSchema: object; }' is not assignable to type 'new (options?: Options) => Ajv'.
```

or 

```
Error:(19, 10) TS2345: Argument of type '{ (options?: Options): Ajv; new (options?: Options): Ajv; ValidationError: typeof ValidationError; MissingRefError: typeof MissingRefError; $dataMetaSchema: object; }' is not assignable to parameter of type 'AjvOrNewable'.
  Type '{ (options?: Options): Ajv; new (options?: Options): Ajv; ValidationError: typeof ValidationError; MissingRefError: typeof MissingRefError; $dataMetaSchema: object; }' is not assignable to type 'new (options?: Options) => Ajv'.
    Types of parameters 'options' and 'options' are incompatible.
      Type 'import("/node_modules/feathers-hooks-common/node_modules/ajv/lib/ajv").Options' is not assignable to type 'import("/node_modules/ajv/lib/ajv").Options'.
        Types of property 'loadSchema' are incompatible.
          Type '(uri: string, cb?: (err: Error, schema: object) => void) => Thenable<boolean | object>' is not assignable to type '(uri: string, cb?: (err: Error, schema: object) => void) => PromiseLike<boolean | object>'.
            Type 'Thenable<boolean | object>' is not assignable to type 'PromiseLike<boolean | object>'.
              Types of property 'then' are incompatible.
                Type '<U>(onFulfilled?: (value: boolean | object) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>) => Thenable<U>' is not assignable to type '<TResult1 = boolean | object, TResult2 = never>(onfulfilled?: (value: boolean | object) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => PromiseLike<...>'.
                  Types of parameters 'onFulfilled' and 'onfulfilled' are incompatible.
                    Type 'TResult1 | PromiseLike<TResult1>' is not assignable to type 'TResult2 | Thenable<TResult2>'.
                      Type 'TResult1' is not assignable to type 'TResult2 | Thenable<TResult2>'.
                        Type 'TResult1' is not assignable to type 'Thenable<TResult2>'.
```
</details>

Seems like the problem should be fixed after this pull request as well. `feathers-hooks-common` types were referenced from its own, older ajv dependency, whereas my application from newer version in my `node_modules`