### PR TITLE
Fix formatting of the Header for the `runHook` documentation

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -455,7 +455,7 @@ Let's you call a hook right after the service call.
   ]
   ```
 
-- ** Details**
+- **Details**
 
   Hooks are normally registered for a service, e.g. in `project/src/services` `/posts/posts.hooks.js`. This is nice and simple when, for example, all the `find` hooks have to run for every `find` call.
 


### PR DESCRIPTION
### Summary

This fixes the formatting of the "Details" header for the `runHook` documentation. Markdown is not forgiving when it comes to incorrect spacing.

**Before**:

> ** Details**

**After**:

> **Details**

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this? **NO**
- [x] Is this PR dependent on PRs in other repos? **NO**

### Other Information

_n/a_