### PR TITLE
Change check for external provider as per daffl in disallow.js by 104c1b1

### DIFF
--- a/lib/services/is-provider.js
+++ b/lib/services/is-provider.js
@@ -11,7 +11,7 @@ module.exports = function (...providers) {
 
     return providers.some(provider => provider === hookProvider ||
       (provider === 'server' && !hookProvider) ||
-      (provider === 'external' && hookProvider)
+      (provider === 'external' && !!hookProvider)
     );
   };
 };


### PR DESCRIPTION
Change check for external provider as per daffl in disallow.js by 104c1b1

### Summary

fixes a 'undefined' to 'boolean' cast flaw in the same way it was already done before for the `disallow` hook.
