### PR TITLE
Fixes populate type definition does not represent the docs

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -346,7 +346,7 @@ export interface PopulateSchema {
      * Call the service as the server, not with the client’s transport.
      */
     provider: string;
-    include: Partial<PopulateSchema>;
+    include: Partial<PopulateSchema> | Partial<PopulateSchema>[];
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -346,7 +346,7 @@ export interface PopulateSchema {
      * Call the service as the server, not with the client’s transport.
      */
     provider: string;
-    include: Partial<PopulateSchema> | Partial<PopulateSchema>[];
+    include: Partial<PopulateSchema> | Array<Partial<PopulateSchema>>;
 }
 
 /**


### PR DESCRIPTION
### Summary
This should fix #594

Just added `| Array<Partial<PopulateSchema>>` to line 349