### PR TITLE
Fix error in docs at utilities#callingparams

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -11,12 +11,10 @@ Build `params` for a service call.
 - **Arguments**
 
   - `{Object} options`
-  - `{Object} context`
 
 | Argument  |   Type   | Default | Description                                                 |
 | --------- | :------: | ------- | ----------------------------------------------------------- |
 | `options` | `Object` |         | How to construct params for service call.                   |
-| `context` | `Object` |         | The `context` of the hook which will make the service call. |
 
 | `options`        | Argument          | Type | Default                                                                                                                      | Description |
 | ---------------- | ----------------- | :--: | ---------------------------------------------------------------------------------------------------------------------------- | ----------- |
@@ -25,10 +23,21 @@ Build `params` for a service call.
 | `newProps`       | `Object`          | `{}` | Additional props to add to the new params.                                                                                   |
 | `hooksToDisable` | `Array< String >` | `[]` | The names of hooks to disable during the service call. `populate`, `fastJoin`, `softDelete` and `stashBefore` are supported. |
 | `ignoreDefaults` | `Boolean`         |      | Ignore the defaults `propNames` and `newProps`.                                                                              |
-
 - **Returns**
 
-  - `{Object} newParams`
+  - `{Function}`
+  
+  - **Arguments**
+
+  - `{Object} context`
+
+| Argument  |   Type   | Default | Description                                                 |
+| --------- | :------: | ------- | ----------------------------------------------------------- |
+| `context` | `Object` |         | The `context` of the hook which will make the service call.   |
+
+  - **Returns**
+
+    - `{Object} newParams`
 
 | Name        |   Type   | Description                      |
 | ----------- | :------: | -------------------------------- |
@@ -48,7 +57,7 @@ Build `params` for a service call.
       propNames: ['customProp'],
       newProps: { mongoose: ... },
       hooksToDisable: 'populate'
-    }), context);
+    }))(context);
     // ...
   }
   ```


### PR DESCRIPTION
### Summary

There is an issue in the doc at [utilities#callingparams](https://hooks-common.feathersjs.com/utilities.html#callingparams)

The doc says that the function takes 2 arguments but when I try, it return a error and after looking for the bug, I found that this function return a [function which require the context](https://github.com/feathersjs-ecosystem/feathers-hooks-common/blob/master/lib/services/calling-params.js).

### Other Information

I try to fix this error but not know if this PR is enough explicit and pretty well written.