### PR TITLE
Fix links for fastJoin and populate

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -575,7 +575,7 @@ Join related records.
 | `after`     | `context` `=> { }` |      | Processing performed after all other operations are completed.                                                             |
 | `joins`     | `Object`           |      | Resolver functions provide a mapping between a portion of a operation and actual backend code responsible for handling it. |
 
-> Read the [guide](guide.html#fastjoin) for more information on the arguments.
+> Read the [guide](guides.html#fastjoin) for more information on the arguments.
 
 - **Example using Feathers services**
 
@@ -1474,7 +1474,7 @@ Join related records.
 | `provider`         | `undefined`                          |                                            | Call the service as the server, not with the client's transport.                                                                                                                                                                                      |
 | `include`          | `Array<` `Object >` or `Object`      |                                            | Continue recursively join records to these records.                                                                                                                                                                                                   |
 
-> Read the [guide](guide.html#populate) for more information on the arguments.
+> Read the [guide](guides.html#populate) for more information on the arguments.
 
 - **Examples**
 


### PR DESCRIPTION
The `guide.html` has changed in `guides.html`.

I've updated the two links.

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: