### PR TITLE
fix(): No patch method

### DIFF
--- a/lib/services/soft-delete.js
+++ b/lib/services/soft-delete.js
@@ -34,9 +34,11 @@ module.exports = ({
 
     if (method === 'remove') {
       const data = await getValue(removeData, context);
-      const result = await service.patch(context.id, data, params);
 
-      context.result = result;
+      try {
+        const result = await service.patch(context.id, data, params);
+        context.result = result;
+      } catch (err) {}
     }
 
     return context;


### PR DESCRIPTION
When using softDelete in `before` `application hooks` for some services that don't have patch method (for example feathers-authentication-management service) it will fail.

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [X] Tell us about the problem your pull request is solving.
When using softDelete as an application hook in combination with `feathers-authentication-management` the `logout` method will fail because softDelete hook would try to patch but `authentication` service doesn't have a patch method.

- [X] Are there any open issues that are related to this?
Not that I found

- [X] Is this PR dependent on PRs in other repos?
No

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: