### PR TITLE
Fix multi record remove cache

### DIFF
--- a/lib/services/cache.js
+++ b/lib/services/cache.js
@@ -16,7 +16,14 @@ module.exports = function (cacheMap, keyFieldName, options = {}) {
     const query = context.params.query || {};
 
     if (context.type === 'after') {
-      if (context.method === 'remove') return;
+      if (context.method === 'remove') {
+        items.forEach(item => {
+          const idName = getIdName(keyFieldName, item);
+          const key = makeCacheKey(item[idName]);
+          cacheMap.delete(key);
+        });
+        return;
+      }
 
       if (query.$select) return;
 

--- a/lib/services/cache.js
+++ b/lib/services/cache.js
@@ -31,6 +31,7 @@ module.exports = function (cacheMap, keyFieldName, options = {}) {
 
     switch (context.method) {
       case 'find': // fall through
+      case 'remove': // skip remove in before remove
       case 'create':
         return;
       case 'get': {

--- a/tests/services/cache.test.js
+++ b/tests/services/cache.test.js
@@ -170,6 +170,18 @@ describe('service cache', () => {
       assert.deepEqual(cacheMap.get(1), 123);
       assert.deepEqual(cacheMap.get(2), 321);
     });
+
+    it('After multi-record remove', () => {
+      hookAfterMulti.method = 'remove';
+
+      cacheMap.set(1, 123);
+      cacheMap.set(2, 321);
+
+      cache(cacheMap, 'id')(hookAfterMulti);
+
+      assert.deepEqual(cacheMap.get(1), undefined, 'id 1');
+      assert.deepEqual(cacheMap.get(2), undefined, 'id 2');
+    });
   });
 
   describe('Loads cache', () => {

--- a/tests/services/cache.test.js
+++ b/tests/services/cache.test.js
@@ -159,6 +159,17 @@ describe('service cache', () => {
       cache(cacheMap, 'id')(hookBeforeSingle);
       assert.deepEqual(cacheMap.get(1), 123);
     });
+
+    it('NOT before multi-record remove', () => {
+      hookBeforeMulti.method = 'remove';
+
+      cacheMap.set(1, 123);
+      cacheMap.set(2, 321);
+
+      cache(cacheMap, 'id')(hookBeforeMulti);
+      assert.deepEqual(cacheMap.get(1), 123);
+      assert.deepEqual(cacheMap.get(2), 321);
+    });
   });
 
   describe('Loads cache', () => {


### PR DESCRIPTION
### Summary

- [ ] Tell us about the problem your pull request is solving.
Currently, if we want to remove multi-record in the cache it will throw error `TypeError: Cannot read property 'id' of undefined`. It is caused because we are trying to access `getItems`  in before remove hook which will return `null`. We can only do `getItems` in after remove hook. Therefore, we need to skip to clear cache in before remove hook and do that in after remove hook instead.

- [ ] Are there any open issues that are related to this?
No

- [ ] Is this PR dependent on PRs in other repos?
No