### PR TITLE
fix(docs/cache): replace 'clone' in arguments table by 'makeCacheKey'

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -190,7 +190,7 @@ Persistent, least-recently-used record cache for services.
 | `options` | Argument   |                      Type                      | Default                                                                                                                                          | Description |
 | --------- | ---------- | :--------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
 | `clone`   | `Function` | `item => JSON.parse(` `JSON.stringify(item) )` | Function to perform a deep clone. See below.                                                                                                     |
-| `clone`   | `Function` |                  `key => key`                  | Function to convert record key to cache key. Use this to convert MongoDB/Mongoose ObjectId/bson keys to a cache key using `item._id.toString()`. |
+| `makeCacheKey`   | `Function` |                  `key => key`                  | Function to convert record key to cache key. Use this to convert MongoDB/Mongoose ObjectId/bson keys to a cache key using `item._id.toString()`. |
 
 - **Example**
 


### PR DESCRIPTION
I just replace 2nd 'clone' option in arguments table of 'cache' hook by 'makeCacheKey'.
There was 2 options named 'clone'
