### PR TITLE
Update guides.md

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -111,9 +111,9 @@ const { fastJoin } = require('feathers-hooks-common')
 
 const postResolvers = {
   joins: {
-    author: (...args) => async post => {
+    author: (...args) => async (post, { app }) => {
       post.author = (
-        await users.find({
+        await app.services('users').find({
           query: {
             id: post.userId
           }
@@ -121,8 +121,8 @@ const postResolvers = {
       )[0]
     },
 
-    starers: $select => async post => {
-      post.starers = await users.find({
+    starers: $select => async (post, { app }) => {
+      post.starers = await app.services('users').find({
         query: {
           id: { $in: post.starIds },
           $select: $select || ['name']


### PR DESCRIPTION
### Summary

The current code causes error, since it tries to access other service which is not defined in the service.
Only changes main fastJoin example, everything else in the page might need some review.