### PR TITLE
Fix the preventChange hook (allowing to use falsy values)

### DIFF
--- a/lib/services/prevent-changes.js
+++ b/lib/services/prevent-changes.js
@@ -26,7 +26,7 @@ module.exports = function (...fieldNames) {
         context.data = omit(data, name);
       }
       // Delete data['contactPerson.name']
-      if (data[name]) {
+      if (data.hasOwnProperty(name)) {
         if (ifThrow) throw new errors.BadRequest(`Field ${name} may not be patched. (preventChanges)`);
         delete data[name];
       }


### PR DESCRIPTION
### Summary


- [ ] Tell us about the problem your pull request is solving.

Currently it is possible to modify a value despite the presence of the preventChange hook because no check is made against negative values, such as 0, false or null for example. This can potentially be a big security hole, as it is possible to remove any value that would normally be protected. By using the object.hasOwnProperty method, we ensure that none of these values can be filled in.

- [ ] Are there any open issues that are related to this?

No.

- [ ] Is this PR dependent on PRs in other repos?

No.