### PR TITLE
fix(getItems): forceArray - always as array

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -204,10 +204,12 @@ Get the records in `context.data` or `context.result`
 
 - **Arguments**
   - `{Object} context`
+  - `{Boolean} forceArray`
 
-| Argument  |   Type   | Default | Description       |
-| --------- | :------: | ------- | ----------------- |
-| `context` | `Object` |         | The hook context. |
+| Argument     |   Type   | Default | Description             |
+| ------------ | :------: | ------- | ----------------------- |
+|   `context`  | `Object` |         | The hook context.       |
+| `forceArray` | `Array`  |         | Always return as array. |
 
 **Returns**
 

--- a/lib/services/get-items.js
+++ b/lib/services/get-items.js
@@ -1,7 +1,9 @@
 
-module.exports = function (context) {
+module.exports = function (context, forceArray = false) {
   if (context.params && context.params._actOn === 'dispatch') return context.dispatch;
 
-  const items = context.type === 'before' ? context.data : context.result;
-  return items && context.method === 'find' ? items.data || items : items;
+  let items = context.type === 'before' ? context.data : context.result;
+  items = items && context.method === 'find' ? items.data || items : items;
+  if (items && forceArray && !Array.isArray(items)) { items = [items]; }
+  return items;
 };

--- a/tests/services/get-replace-items.test.js
+++ b/tests/services/get-replace-items.test.js
@@ -69,6 +69,11 @@ describe('services getItems & replaceItems', () => {
       assert.deepEqual(stuff, { first: 'John', last: 'Doe' });
     });
 
+    it('updates hook before::create item with forceArray', () => {
+      const stuff = hooks.getItems(hookBefore, true);
+      assert.deepEqual(stuff, [{ first: 'John', last: 'Doe' }]);
+    });
+
     it('updates hook before::create items', () => {
       const stuff = hooks.getItems(hookBeforeArray);
       assert.deepEqual(stuff, [
@@ -80,6 +85,11 @@ describe('services getItems & replaceItems', () => {
     it('updates hook after::create item', () => {
       const stuff = hooks.getItems(hookAfter);
       assert.deepEqual(stuff, { first: 'Jane2', last: 'Doe2' });
+    });
+
+    it('updates hook after::create item with forceArray', () => {
+      const stuff = hooks.getItems(hookAfter, true);
+      assert.deepEqual(stuff, [{ first: 'Jane2', last: 'Doe2' }]);
     });
 
     it('updates hook after::create items', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -221,7 +221,7 @@ export function fgraphql(options?: FGraphQLHookOptions): Hook;
  * Get the records in context.data or context.result[.data]. (Utility function.)
  * {@link https://hooks-common.feathersjs.com/hooks.html#GetItems}
  */
-export function getItems(context: HookContext): any; // any[] | any | undefined;
+export function getItems(context: HookContext, forceArray?: boolean): any; // any[] | any | undefined;
 
 /**
  * Check which transport provided the service call.


### PR DESCRIPTION
Almost evertime I do this:

```js
const itemOrItems = getItems(context);
const items = (Array.isArray(itemOrItems)) ? itemOrItems : [itemOrItems]
```

even for `get`, `update`, `patch`, `remove`. It would be neat, to only call this:
`const items = getItems(context, true)`

No breaking changes, `forceArray` is `false` by default. Tests added. Docs added. Types added.

If there's something, I'm also happy to discuss/make changes.