### PR TITLE
refactor(set-field hooks): Handle 'as' field startsWith data and data type array

### DIFF
--- a/src/hooks/set-field.ts
+++ b/src/hooks/set-field.ts
@@ -22,7 +22,7 @@ export function setField (
   }
 
   return context => {
-    const { params, app } = context;
+    const { data, params, app } = context;
 
     if (app.version < '4.0.0') {
       throw new Error('The \'setField\' hook only works with Feathers 4 and the latest database adapters');
@@ -39,6 +39,22 @@ export function setField (
       }
 
       throw new Forbidden(`Expected field ${as} not available`);
+    }
+
+    debug(`If ${as} startsWith data, setting value '${value}' from '${from}' to each array of data`);
+
+    if(typeof data !== 'undefined' && Array.isArray(data) && as.startsWith('data')) {
+      for (const [index] of data.entries()) {
+        if (Array.isArray(as)) {
+          data[index][as[as.length - 1]] = value;
+        } else {
+          const asDot = as.split('.');
+          if (asDot.length > 0) {
+            data[index][asDot[asDot.length - 1]] = value;
+          }
+        }
+      }
+      return _setWith(context, data, value, _clone);
     }
 
     debug(`Setting value '${value}' from '${from}' as '${as}'`);


### PR DESCRIPTION
To handle the use case where `multi:true`, `create` method, the data is in array format. E.g
Inside hook
```
before: {
  all: [],
  find: [],
  get: [],
  create: [setField({ from: "params.user.id", as: "data.user_id" })]
  update:[],
  patch: [],
  remove: []
}
```
When POST array of data, currently the merge result will become
```
[ 
  { key: data, key2: data },
  { sample: data, sample2: data },
  user_id: "sample_id"
]
```
Expected result:
```
[ 
  { key: data, key2: data, user_id: "sample_id" },
  { sample: data, sample2: data, user_id: "sample_id" }
]
```
