### PR TITLE
fix(prevent-changes): return original context object

### DIFF
--- a/src/hooks/prevent-changes.ts
+++ b/src/hooks/prevent-changes.ts
@@ -34,6 +34,8 @@ export function preventChanges<H extends HookContext = HookContext>(
       }
     });
 
-    return { ...context, data };
+    context.data = data;
+
+    return context;
   };
 }


### PR DESCRIPTION
This PR fixes `preventChanges` to return the original `context` object instead of a new shallow cloned one.

see #709