### PR TITLE
Pass additionalProperty name in nested objects to validateSchema error messages

### DIFF
--- a/src/hooks/validate-schema.ts
+++ b/src/hooks/validate-schema.ts
@@ -83,9 +83,10 @@ function addNewErrorDflt(errorMessages: any, ajvError: any, itemsLen: any, index
     message = `'${leader}${ajvError.dataPath.substring(1)}' ${ajvError.message}`;
   } else {
     message = `${leader}${ajvError.message}`;
-    if (ajvError.params && ajvError.params.additionalProperty) {
-      message += `: '${ajvError.params.additionalProperty}'`;
-    }
+  }
+
+  if (ajvError.params && ajvError.params.additionalProperty) {
+    message += `: '${ajvError.params.additionalProperty}'`;
   }
 
   return (errorMessages || []).concat(message);

--- a/test/hooks/validate-schema.test.ts
+++ b/test/hooks/validate-schema.test.ts
@@ -11,6 +11,10 @@ ajv.addSchema({
   properties: {
     first: { type: 'string', format: 'startWithJo' },
     last: { type: 'string' },
+    nested: {
+      type: 'object',
+      additionalProperties: false,
+    },
   },
   required: ['first', 'last'],
 });
@@ -55,6 +59,9 @@ describe('services validateSchema', () => {
       properties: {
         first: { type: 'string' },
         last: { type: 'string' },
+        nested: {
+          additionalProperties: false,
+        },
       },
       required: ['first', 'last'],
     };
@@ -62,6 +69,9 @@ describe('services validateSchema', () => {
       properties: {
         first: { type: 'string', format: 'startWithJo' },
         last: { type: 'string' },
+        nested: {
+          additionalProperties: false,
+        },
       },
       required: ['first', 'last'],
     };
@@ -159,6 +169,17 @@ describe('services validateSchema', () => {
           '\'in row 2 of 3, first\' should match format "startWithJo"',
           "in row 3 of 3, should have required property 'last'",
         ]);
+      }
+    });
+
+    it('properly displays incorrect additional properties in nested objects', () => {
+      hookBefore.data.nested = { foo: 'bar' };
+
+      try {
+        validateSchema(schemaForAjvInstance, ajv)(hookBefore);
+        assert.fail(true, false, 'test succeeds unexpectedly');
+      } catch (err: any) {
+        assert.deepEqual(err.errors, ["'nested' should NOT have additional properties: 'foo'"]);
       }
     });
   });


### PR DESCRIPTION
This fixes a bug in `validateSchema` hook where error messages related to invalid additional properties in nested objects didn't contain the name of said erroneous property.