### PR TITLE
[docs] Fix softDelete arguments array

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1877,7 +1877,7 @@ Flag records as logically deleted instead of physically removing them. Requires 
 
 - **Arguments**
 
-| Argument       | Type      | Default | Description                  |
+| Argument       | Type      | Default | Description                  |                                                                                                                |
 | -------------- | --------- | ------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `deletedQuery` | `Function | Object` | `{ deleted: { $ne: true } }` | An object or async function that takes the query which returns the part of the query to exclude deleted entrie |
 | `removeData`   | `Function | Object` | `{ deleted: true }`          | An object or async function that returns the data used to flag an entry as deleted                             |


### PR DESCRIPTION
In the documentation, the array of arguments of  `softDelete` hooks is broken.

https://hooks-common.feathersjs.com/hooks.html#softdelete

This should fix it.