### PR TITLE
docs(traverse): replace dead link

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1960,7 +1960,7 @@ Transform fields & objects in place in the record(s) using a recursive walk. Pow
 
   Traverse and transform objects in place by visiting every node on a recursive walk. Any object in the hook may be traversed, including the query object.
 
-  > [substack/js-traverse](https://github.com/substack/js-traverse) documents the extensive methods and context available to the transformer function.
+  > [traverse (NPM)](https://npmjs.com/package/traverse) documents the extensive methods and context available to the transformer function.
 
 ## unless
 


### PR DESCRIPTION
### Summary

The [`traverse` documentation](https://hooks-common.feathersjs.com/hooks.html#traverse) contains a link to a repository that no longer exists. It appears the source code got moved to a [different repo](https://github.com/ljharb/js-traverse). This PR replaces it with a link to the package on NPM, as I figured that will always be up-to-date.