### PR TITLE
feat: neotraverse/legacy; v0.6.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "debug": "^4.3.5",
         "graphql": "^16.9.0",
         "lodash": "^4.17.21",
-        "neotraverse": "^0.6.11"
+        "neotraverse": "^0.6.14"
       },
       "devDependencies": {
         "@feathers-plus/batch-loader": "^0.3.6",
@@ -7893,9 +7893,9 @@
       }
     },
     "node_modules/neotraverse": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.11.tgz",
-      "integrity": "sha512-OdydhNAkoRxXyxz1d8Cx2rQS0wfTcoSlBNIuv/PMC/0CrwTYUBMy+kIa7h3y18lVyvgARazb4ugVZ5n/aly2PA==",
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.14.tgz",
+      "integrity": "sha512-co+mqQYo1wf3CRWRHWOT1ZgG7gsdNZSrrQkWxVnGAlD/UA/IZuPlE9UNkGZRwTLeml+dT5BytRW4ANqzPQeNLg==",
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -17816,9 +17816,9 @@
       "dev": true
     },
     "neotraverse": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.11.tgz",
-      "integrity": "sha512-OdydhNAkoRxXyxz1d8Cx2rQS0wfTcoSlBNIuv/PMC/0CrwTYUBMy+kIa7h3y18lVyvgARazb4ugVZ5n/aly2PA=="
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.14.tgz",
+      "integrity": "sha512-co+mqQYo1wf3CRWRHWOT1ZgG7gsdNZSrrQkWxVnGAlD/UA/IZuPlE9UNkGZRwTLeml+dT5BytRW4ANqzPQeNLg=="
     },
     "node-gyp": {
       "version": "9.4.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "debug": "^4.3.5",
     "graphql": "^16.9.0",
     "lodash": "^4.17.21",
-    "neotraverse": "^0.6.11"
+    "neotraverse": "^0.6.14"
   },
   "devDependencies": {
     "@feathers-plus/batch-loader": "^0.3.6",

--- a/src/common/traverse.ts
+++ b/src/common/traverse.ts
@@ -1,4 +1,4 @@
-import traverser from 'neotraverse';
+import traverser from 'neotraverse/legacy';
 
 export function traverse<T extends Record<string, any>>(
   items: T | T[],

--- a/src/hooks/mongo-keys.ts
+++ b/src/hooks/mongo-keys.ts
@@ -26,7 +26,7 @@ export function mongoKeys<H extends HookContext = HookContext>(
     checkContext(context, 'before', null, 'mongoKeys');
     const query = context.params.query || {};
 
-    traverse(query).forEach(function (this: any, node: any) {
+    traverse(query).forEach(function (node: any) {
       const typeofNode = typeof node;
       const key = this.key;
       const path = this.path;

--- a/src/hooks/mongo-keys.ts
+++ b/src/hooks/mongo-keys.ts
@@ -1,5 +1,5 @@
 import type { HookContext } from '@feathersjs/feathers';
-import traverse from 'neotraverse';
+import traverse from 'neotraverse/legacy';
 import { checkContext } from '../utils/check-context';
 
 /**


### PR DESCRIPTION
### Summary

- Bumps neotraverse to 0.6.14 minimum
- Use neotraverse/legacy as the build still relies on CommonJS. Issue caught in https://github.com/feathersjs-ecosystem/feathers-hooks-common/pull/753#issuecomment-2241460378

Closes #753