### PR TITLE
feat: neotraverse/legacy; v0.6.14

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,9 +7,9 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -18,9 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
       - run: npm install

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.5.1]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "debug": "^4.3.5",
         "graphql": "^16.9.0",
         "lodash": "^4.17.21",
-        "neotraverse": "^0.6.11"
+        "neotraverse": "^0.6.14"
       },
       "devDependencies": {
         "@feathers-plus/batch-loader": "^0.3.6",
@@ -7893,9 +7893,9 @@
       }
     },
     "node_modules/neotraverse": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.11.tgz",
-      "integrity": "sha512-OdydhNAkoRxXyxz1d8Cx2rQS0wfTcoSlBNIuv/PMC/0CrwTYUBMy+kIa7h3y18lVyvgARazb4ugVZ5n/aly2PA==",
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.14.tgz",
+      "integrity": "sha512-co+mqQYo1wf3CRWRHWOT1ZgG7gsdNZSrrQkWxVnGAlD/UA/IZuPlE9UNkGZRwTLeml+dT5BytRW4ANqzPQeNLg==",
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -17816,9 +17816,9 @@
       "dev": true
     },
     "neotraverse": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.11.tgz",
-      "integrity": "sha512-OdydhNAkoRxXyxz1d8Cx2rQS0wfTcoSlBNIuv/PMC/0CrwTYUBMy+kIa7h3y18lVyvgARazb4ugVZ5n/aly2PA=="
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.14.tgz",
+      "integrity": "sha512-co+mqQYo1wf3CRWRHWOT1ZgG7gsdNZSrrQkWxVnGAlD/UA/IZuPlE9UNkGZRwTLeml+dT5BytRW4ANqzPQeNLg=="
     },
     "node-gyp": {
       "version": "9.4.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "debug": "^4.3.5",
     "graphql": "^16.9.0",
     "lodash": "^4.17.21",
-    "neotraverse": "^0.6.11"
+    "neotraverse": "^0.6.14"
   },
   "devDependencies": {
     "@feathers-plus/batch-loader": "^0.3.6",

--- a/src/common/traverse.ts
+++ b/src/common/traverse.ts
@@ -1,4 +1,4 @@
-import traverser from 'neotraverse';
+import traverser from 'neotraverse/legacy';
 
 export function traverse<T extends Record<string, any>>(
   items: T | T[],

--- a/src/hooks/mongo-keys.ts
+++ b/src/hooks/mongo-keys.ts
@@ -26,7 +26,7 @@ export function mongoKeys<H extends HookContext = HookContext>(
     checkContext(context, 'before', null, 'mongoKeys');
     const query = context.params.query || {};
 
-    traverse(query).forEach(function (this: any, node: any) {
+    traverse(query).forEach(function (node: any) {
       const typeofNode = typeof node;
       const key = this.key;
       const path = this.path;

--- a/src/hooks/mongo-keys.ts
+++ b/src/hooks/mongo-keys.ts
@@ -1,5 +1,5 @@
 import type { HookContext } from '@feathersjs/feathers';
-import traverse from 'neotraverse';
+import traverse from 'neotraverse/legacy';
 import { checkContext } from '../utils/check-context';
 
 /**


### PR DESCRIPTION
This is a follow up of #755 which changes the new 'neotraverse' dependency to 'neotraverse/legacy' for cjs modules.

#755 couldn't be merged because of a regression in node@22.5.0 (see https://github.com/npm/cli/issues/7657). 22.5.1 is out and fixes this but it's not picked up by gh action 'actions/setup-node' yet. So as a temporary fix I set v22.5.1 explicitly in the 'node-version' matrix. We'll need to revert it to '22.x' in a future PR.

Thanks @PuruVJ for the fix! Thanks @eXigentCoder for the report in #753. 

Closes #755